### PR TITLE
Added exit() function to scene

### DIFF
--- a/lib/scenemanager.js
+++ b/lib/scenemanager.js
@@ -68,9 +68,11 @@ function SceneManager(p)
                     oScene: oScene,
                     hasSetup : "setup" in oScene,
                     hasEnter : "enter" in oScene,
+                    hasExit : "exit" in oScene,
                     hasDraw : "draw" in oScene,
                     setupExecuted : false,
-                    enterExecuted : false };
+                    enterExecuted : false,
+                    exitExecuted : false };
 
         this.scenes.push(o);
         return o;
@@ -110,6 +112,13 @@ function SceneManager(p)
     // Arguments will be retrieved in the scene via .sceneArgs property
     this.showScene = function( fnScene, sceneArgs )
     {
+        var currScene = this.scene;
+        if ( currScene != null && currScene.hasExit && !currScene.exitExecuted  )
+        {            
+            currScene.oScene.exit();
+            currScene.exitExecuted = true;
+        }
+
         var o = this.findScene( fnScene );
 
         if ( o == null )
@@ -117,6 +126,7 @@ function SceneManager(p)
         
         // Re-arm the enter function at each show of the scene
         o.enterExecuted = false;
+        o.exitExecuted = false;
 
         this.scene = o;
 
@@ -133,12 +143,13 @@ function SceneManager(p)
             return;
 
         var nextSceneIndex = 0;
+        var currScene = this.scene;
 
-        if ( this.scene != null )
+        if ( currScene != null )
         {
             // search current scene... 
             // can be optimized to avoid searching current scene...
-            var i = this.findSceneIndex( this.scene.fnScene );
+            var i = this.findSceneIndex( currScene.fnScene );
             nextSceneIndex = i < this.scenes.length - 1 ? i + 1 : 0;
         }
 
@@ -177,7 +188,7 @@ function SceneManager(p)
     }
 
 
-    // Handle a certain even for a scene... 
+    // Handle a certain event for a scene... 
     // It is used by the anonymous functions from the wire() function
     this.handleEvent = function(sEvent)
     {


### PR DESCRIPTION
When a scene is terminated by calling nextScene(), an exit( function is called. This is useful for cleaning up stuff after a scene is finished.