### PR TITLE
Added windowResized wiring

### DIFF
--- a/lib/scenemanager.js
+++ b/lib/scenemanager.js
@@ -32,7 +32,8 @@ function SceneManager(p)
                 "touchEnded", 
                 "deviceMoved", 
                 "deviceTurned", 
-                "deviceShaken" ];
+                "deviceShaken",
+                "windowResized" ];
 
         var me = this;
         var o = p != null ? p : window;


### PR DESCRIPTION
Fixes the final part of issue #1 using SceneManager's newer, DRYer event handling.

I don't believe SceneManager objects ever had a `windowResized` method, but if they had, the following code may be added at the end of the SceneManager constructor function:

```javascript
    
    // Legacy method... preserved for maintaining compatibility
    this.windowResized = function()
    {
        this.handleEvent("windowResized");
    }
```